### PR TITLE
Fix NZ link

### DIFF
--- a/list.csv
+++ b/list.csv
@@ -34,7 +34,7 @@ https://www.gov.scot/coronavirus-covid-19/,Scotland,
 https://www.gov.sg/features/covid-19,Singapore,National
 https://www.gov.uk/coronavirus,UK,National
 https://www.government.nl/topics/coronavirus-covid-19,Netherlands,National
-https://www.govt.nz/covid-19-novel-coronavirus/,New Zealand,National
+https://covid19.govt.nz/,New Zealand,National
 https://www.health.ny.gov/diseases/communicable/coronavirus/,New York,State
 https://coronavirus.health.ny.gov/home,New York,State
 https://www.info-coronavirus.be/fr/,Belgium,National


### PR DESCRIPTION
New Zealand has [a dedicated site](https://covid19.govt.nz) for COVID-19 related information.

The [previous link](https://www.govt.nz/covid-19-novel-coronavirus) is just a redirection to this website.